### PR TITLE
Add CHARTER.md

### DIFF
--- a/CHARTER.md
+++ b/CHARTER.md
@@ -32,7 +32,7 @@ This Technical Charter sets forth the responsibilities and procedures for techni
 
 - e. The TSC may create, change, modify, or remove roles or their definitions, so long as the definitions of roles for the Technical Initiative are publicly available in the Technical Initiative repository.
 
-- f. The TSC may elect a TSC Chair, who will preside over meetings of the TSC and will serve until their resignation or replacement by the TSC.  **The TSC Chair, or any other TSC member so designated by the TSC, will serve as the Technical Initiative’s voting representative on the OpenSSF’s Technical Advisory Council (the "TAC").
+- f. The TSC may elect a TSC Chair, who will preside over meetings of the TSC and will serve until their resignation or replacement by the TSC.
 
 - g. Responsibilities: The TSC will be responsible for all aspects of oversight relating to the Technical Initiative, which may include:
 

--- a/CHARTER.md
+++ b/CHARTER.md
@@ -4,7 +4,7 @@ Supply Chain Integrity - Working Group
 
 Adopted [DATE]
 
-This Technical Charter sets forth the responsibilities and procedures for technical contribution to, and oversight of, the Supply Chain Integrity open source community, which has been established as a Working Group (the "Technical Initiative") under the Open Source Security Foundation (the “OpenSSF”).  All contributors (including committers, maintainers, and other technical positions) and other participants in the Technical Initiative (collectively, “Collaborators”) must comply with the terms of this Technical Charter and the OpenSSF Charter.
+This Technical Charter sets forth the responsibilities and procedures for technical contribution to, and oversight of, the Supply Chain Integrity Working Group (the "Technical Initiative") under the Open Source Security Foundation (the “OpenSSF”).  All contributors (including committers, maintainers, and other technical positions) and other participants in the Technical Initiative (collectively, “Collaborators”) must comply with the terms of this Technical Charter and the OpenSSF Charter.
 
 #### 1. Mission and Scope of the Technical Initiative
 

--- a/CHARTER.md
+++ b/CHARTER.md
@@ -1,0 +1,112 @@
+# Technical Charter for Open Source Security Foundation
+
+Supply Chain Integrity - Working Group
+
+Adopted [DATE]
+
+This Technical Charter sets forth the responsibilities and procedures for technical contribution to, and oversight of, the Supply Chain Integrity open source community, which has been established as a Working Group (the "Technical Initiative") under the Open Source Security Foundation (the “OpenSSF”).  All contributors (including committers, maintainers, and other technical positions) and other participants in the Technical Initiative (collectively, “Collaborators”) must comply with the terms of this Technical Charter and the OpenSSF Charter.
+
+#### 1. Mission and Scope of the Technical Initiative
+
+- a. The mission of the Technical Initiative is to provide a global community for collaborating to help individuals and organizations assess and improve the security of end-to-end supply chains for open source software.
+
+- b. The scope of the Technical Initiative includes collaborative development under the Technical Initiative License (as defined herein) supporting the mission, including organizing collaboration activities, defining best practices, documentation, testing, integration, and the creation of other artifacts that support the mission.
+
+#### 2. Technical Steering Committee
+
+- a. The Technical Steering Committee (the "TSC") will be responsible for all oversight of the Technical Initiative.
+
+- b. The TSC voting members are initially the Technical Initiative’s Maintainers. The Maintainers will be documented in the Technical Initiative repository. The TSC is responsible for determining the future process for defining voting members of the TSC, and any such alternative approach will also be documented appropriately.  Any meetings of the Technical Steering Committee are intended to be open to the public, and can be conducted electronically, via teleconference, or in person.
+
+- c. The Technical Initiative generally will involve Collaborators and Contributors. The TSC may adopt or modify additional roles so long as the roles are documented in the Technical Initiative’s repository. Unless otherwise documented:
+
+   - i. Contributors include anyone in the technical community that contributes effort, ideas, code, documentation, or other artifacts to the Technical Initiative;
+
+   - ii. Collaborators are Contributors who have earned the ability to modify ("commit") text, source code, documentation or other artifacts in the Technical Initiative’s repository or direct the agenda or working activities of the Technical Initiative; and
+
+   - iii. A Contributor may become a Collaborator by a majority approval of the existing Collaborators. A Collaborator may be removed by a majority approval of the other existing Collaborators.
+
+   - iv. Maintainers are the initial Collaborators defined at the creation of the Technical Initiative. The Maintainers will determine the process for selecting future Maintainers. A Maintainer may be removed by two-thirds approval of the other existing Maintainers, or a majority of the other existing Collaborators.
+
+- d. Participation in the Technical Initiative through becoming a Contributor, Collaborator, or Maintainer is open to anyone, whether a OpenSSF member or not, so long as they abide by the terms of this Technical Charter.
+
+- e. The TSC may create, change, modify, or remove roles or their definitions, so long as the definitions of roles for the Technical Initiative are publicly available in the Technical Initiative repository.
+
+- f. The TSC may elect a TSC Chair, who will preside over meetings of the TSC and will serve until their resignation or replacement by the TSC.  **The TSC Chair, or any other TSC member so designated by the TSC, will serve as the Technical Initiative’s voting representative on the OpenSSF’s Technical Advisory Council (the "TAC").
+
+- g. Responsibilities: The TSC will be responsible for all aspects of oversight relating to the Technical Initiative, which may include:
+
+   - i. coordinating the direction of the Technical Initiative;
+
+   - ii. approving, organizing or removing activities and projects;
+
+   - iii. establish community norms, workflows, processes, release requirements, and templates for the operation of the Technical Initiative;
+
+   - iv. establish a fundraising model, and approve or modify a Technical Initiative budget, subject to OpenSSF Governing Board approval;
+
+   - v. appointing representatives to work with other open source or open standards communities;
+
+   - vi. approving and implementing policies and processes for contributing (to be published in the Technical Initiative repository) and coordinating with the Linux Foundation to resolve matters or concerns that may arise as set forth in Section 6 of this Technical Charter;
+
+   - vii. facilitating discussions, seeking consensus, and where necessary, voting on technical matters relating to the Technical Initiative; and
+
+   - viii. coordinating any communications regarding the Technical Initiative.
+
+#### 3. TSC Voting
+
+- a. While the Technical Initiative aims to operate as a consensus-based community, if any TSC decision requires a vote to move the Technical Initiative forward, the voting members of the TSC will vote on a one vote per voting member basis.
+
+- b. Quorum for TSC meetings requires at least fifty percent of all voting members of the TSC to be present. The TSC may continue to meet if quorum is not met but will be prevented from making any decisions at the meeting.
+
+- c. Except as provided in Section 7.c. and 8.a, decisions by vote at a meeting require a majority vote of those in attendance, provided quorum is met. Decisions made by electronic vote without a meeting require a majority vote of all voting members of the TSC.
+
+- d. In the event a vote cannot be resolved by the TSC, any voting member of the TSC may refer the matter to the TAC for assistance in reaching a resolution.
+
+#### 4. Compliance with Policies
+
+- a. This Technical Charter is subject to the OpenSSF Charter and any rules or policies established for all Technical Initiatives.
+
+- b. The Technical Initiative participants must conduct their business in a professional manner, subject to the Contributor Covenant Code of Conduct 2.0, available at [https://www.contributor-covenant.org/version/2/0/code_of_conduct](https://www.contributor-covenant.org/version/2/0/code_of_conduct/). The TSC may adopt a different code of conduct ("CoC") for the Technical Initiative, subject to approval by the TAC.
+
+- c. All Collaborators must allow open participation from any individual or organization meeting the requirements for contributing under this Technical Charter and any policies adopted for all Collaborators by the TSC, regardless of competitive interests. Put another way, the Technical Initiative community must not seek to exclude any participant based on any criteria, requirement, or reason other than those that are reasonable and applied on a non-discriminatory basis to all Collaborators in the Technical Initiative community. All activities conducted in the Technical Initiative are subject to the Linux Foundation’s Antitrust Policy, available at [https://www.linuxfoundation.org/antitrust-policy](https://www.linuxfoundation.org/antitrust-policy/).
+
+- d. The Technical Initiative will operate in a transparent, open, collaborative, and ethical manner at all times. The output of all Technical Initiative discussions, proposals, timelines, decisions, and status should be made open and easily visible to all. Any potential violations of this requirement should be reported immediately to the TAC.
+
+#### 5. Community Assets
+
+- a. The Linux Foundation will hold title to all trade or service marks used by the Technical Initiative ("Technical Initiative Trademarks"), whether based on common law or registered rights.  Technical Initiative Trademarks may be transferred and assigned to LF Technical Initiatives to hold on behalf of the Technical Initiative. Any use of any Technical Initiative Trademarks by Collaborators in the Technical Initiative will be in accordance with the trademark usage policy of the Linux Foundation, available at [https://www.linuxfoundation.org/trademark-usage](https://www.linuxfoundation.org/trademark-usage/), and inure to the benefit of the Linux Foundation.
+
+- b. The Linux Foundation or Technical Initiative must own or control the repositories, social media accounts, and domain name registrations created for use by the Technical Initiative community.
+
+- c. Under no circumstances will the Linux Foundation be expected or required to undertake any action on behalf of the Technical Initiative that is inconsistent with the policies or tax-exempt status or purpose, as applicable, of the Linux Foundation.
+
+#### 6. Intellectual Property Policy
+
+- a. Collaborators acknowledge that the copyright in all new contributions will be retained by the copyright holder as independent works of authorship and that no contributor or copyright holder will be required to assign copyrights to the Technical Initiative.
+
+- b. Except as described in Section 6.c., all contributions to the Technical Initiative are subject to the following:
+
+  - i. All new inbound code contributions to the Technical Initiative must be made using the Apache License, Version 2.0, available at [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0) (the "Technical Initiative License").
+
+  - ii. All new inbound code contributions must also be accompanied by a Developer Certificate of Origin ([http://developercertificate.org](http://developercertificate.org)) sign-off in the source code system that is submitted through a TSC-approved contribution process which will bind the authorized contributor and, if not self-employed, their employer to the applicable license;
+
+  - iii. All outbound code will be made available under the Technical Initiative License.
+
+  - iv. Documentation will be received and made available by the Technical Initiative under the Creative Commons Attribution 4.0 International License, available at [http://creativecommons.org/licenses/by/4.0/](http://creativecommons.org/licenses/by/4.0/).
+
+  - v. To the extent a contribution includes or consists of data, any rights in such data shall be made available under the CDLA-Permissive 1.0 License.
+
+  - vi. The Technical Initiative may seek to integrate and contribute back to other open source projects ("Upstream Projects"). In such cases, the Technical Initiative will conform to all license requirements of the Upstream Projects, including dependencies, leveraged by the Technical Initiative.  Upstream Project code contributions not stored within the Technical Initiative’s main code repository will comply with the contribution process and license terms for the applicable Upstream Project.
+
+- c. The TSC may approve the use of an alternative license or licenses for inbound or outbound contributions on an exception basis. To request an exception, please describe the contribution, the alternative open source license(s), and the justification for using an alternative open source license for the Technical Initiative. License exceptions must be approved by a two-thirds vote of the entire Governing Board.
+
+- d. Contributed files should contain license information, such as SPDX short form identifiers, indicating the open source license or licenses pertaining to the file.
+
+#### 7. Amendments
+
+- a. This charter may be amended by a two-thirds vote of the entire TSC and is subject to approval by the TAC.
+
+#### 8. Maintainers
+
+- a. For the purposes of this document, the Maintainers are as follows:
+  * To be determined by discussion in PR

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Subscribe to the calendar for meeting details.
 Meeting Notes and Agendas are available on [Google Drive](https://docs.google.com/document/d/1xPs2sSbH3I9Ich7OyLOzl85oJshnK8Q6WoAgREE5-zA/edit). (Join the group listed under communications to edit.)
 
 ## Documents
-Documents for the working group can be found in the following Google Drive location: 
+Documents for the working group can be found in the following Google Drive location:
 https://drive.google.com/drive/folders/14VpLCYYAEZt1OQn490ajBg28TKXNPuUJ?usp=sharing
 
 Documents include the following:
@@ -40,12 +40,12 @@ Documents include the following:
 
 ## Governance
 
-This WG is chaired by Kim Lewandowski and Dan Lorenc
+This WG is chaired by Kim Lewandowski and Dan Lorenc.
 
 Working Group operations are consistent with standard operating guidelines provided by the OSSF Technical Advisory Committee
 [TAC](https://github.com/ossf/tac).
 
-Full details of process and roles are linked from [governance README](/governance).
+The [CHARTER.md](https://github.com/ossf/wg-wg-supply-chain-integrity/blob/main/CHARTER.md) outlines the scope and governance of our group activities.
 
 ## Antitrust policy
 

--- a/governance/README.md
+++ b/governance/README.md
@@ -1,3 +1,0 @@
-# Governance
-
-TODO


### PR DESCRIPTION
This pull request introduces `CHARTER.md`, based on the standard template provided by the OpenSSF. The pull request is in response to the request made by the TAC in #49.

At submission, this PR is **not currently in a mergeable state**. To be merged:

1. There needs to be agreement on the list of Maintainers, and
2. The CHARTER.md needs to be adopted on a particular date; ideally with consent from nominated Maintainers signalled by leaving positive reviews on this PR.

Based on [aggregating meeting notes](https://docs.google.com/spreadsheets/d/1I7xX3wkVHnKkqDHUTBbIWym4PejpCHKAvViv1eLDxhU/edit#gid=0), my preliminary suggestion for a Maintainers list is:

- Kim Lewandowski (Chainguard)
- Mike Malone (smallstep)
- Dan Lorenc (Chainguard)
- Ryan Haning (Microsoft)
- Gavin Hindman (Intel)
- Michael Peters (Red Hat)
- Matt Rutkowski (IBM)

These are people whose names appear >= 10 times in the notes as attendees and who are not LF staff. 

However, some have not been active for some time and it may make sense to strike their names and promote others with fewer attendances. For example, it may make sense to promote Santiago Torres-Arias to the list; he has 9 attendances recorded and broadens our list to include academia.

Overall, though, I suggest that no more than 10 names be chosen to ensure easy quorum for the rare occasions when a vote will be required under the charter's rules.
