### PR TITLE
Update chair and co-chairs

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Older activities (as Digital Identity Attestation WG):
 
 ## Governance
 
-This WG is chaired by Kim Lewandowski and Dan Lorenc
+This WG is chaired by Isaac Hepworth. Melba Lopez and Jay White are co-chairs.
 
 Working Group operations are consistent with standard operating guidelines provided by the OSSF Technical Advisory Committee
 [TAC](https://github.com/ossf/tac).


### PR DESCRIPTION
Over the last several months neither Kim nor Dan have been able to be closely involved in the SCI WG as they apply their energies elsewhere in OpenSSF. In the SCI WG meeting today there was a proposal to update the documented chair and co-chairs of the WG to reflect the effective change in stewardship; see meeting notes https://docs.google.com/document/d/1xPs2sSbH3I9Ich7OyLOzl85oJshnK8Q6WoAgREE5-zA/edit#heading=h.typqfpgh3dos. 

The proposal 
- Isaac Hepworth (chair)
- Melba Lopez (co-chair)
- Jay White (co-chair) was mooted, and accepted, with no recorded objections (meeting video link tk).

As discussed in the meeting — and subsequently with Dan and Kim — I invite comments, emojis, thumbs-up, thumbs-down, etc., from the broader team via this PR.