### PR TITLE
chore(docs): add Zarf to list of WG activities

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Meeting Notes and Agendas are available on [Google Drive](https://docs.google.co
 * Supply Chain Integrity Positioning Special Interest Group (SIG)
 * [gittuf: A security layer for Git repositories](https://github.com/gittuf/gittuf)
 * [Graph for Understanding Artifact Composition (GUAC)](https://guac.sh) - see also the [GUAC repository](https://github.com/guacsec/guac)
+* [Zarf: Secure Software Delivery to Disconnected Systems](https://zarf.dev) - see also the [Zarf repository](https://github.com/zarf-dev/zarf)
 
 Older activities (as Digital Identity Attestation WG):
   * [Former Digital Identity Attestation WG Readme](https://github.com/ossf/wg-supply-chain-integrity/blob/0804679461f7ed288d50d70da7ae9c7152b1e51d/README.md)


### PR DESCRIPTION
Adding a mention to Zarf - an SCI WG project (OpenSSF Sandbox) - to the repository readme. 