### PR TITLE
Propose Charter v2.0: refocus on maintainer enablement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,18 @@
 # Supply Chain Integrity WG
 
-## Objective
+> **Maintainers — start here:** the SCI WG is being repositioned (Q3 2026) as the OpenSSF maintainer front door. See the proposed [Charter v2.0](./governance/CHARTER.md). Comments and contributions welcome on the mailing list and in `#wg_supply_chain_integrity` on the OpenSSF Slack.
 
-The objective of the Supply Chain Integrity Working Group (WG) is to provide a global community for collaborating to help individuals and organizations assess and improve the security of end-to-end supply chains for open source software.
+## Mission
+
+**Make adopting OpenSSF security tooling the easy default for open-source maintainers.**
+
+The Supply Chain Integrity Working Group is the OpenSSF front door for maintainers adopting security tooling — a brokering layer that routes maintainer needs to the right sibling WG, sponsors Technical Initiatives whose value is friction reduction, and turns the OpenSSF "Producer Enablement" pillar and the OSPS Baseline into a low-friction adoption path.
+
+The shorthand: **sub-projects build the tools; the WG makes them adoptable.**
 
 ## Motivation
 
-Supply chain issues and attacks cause significant damage worldwide including lost revenue, costs of ransomware payments, costs of mitigation, denial of access to resources, reduced customer trust, and public deception. As a matter of public trust, governments are beginning to mandate actions aimed at improving the security and integrity of supply chains. The [US White House Executive Order on Improving the Nation’s Cybersecurity](https://www.whitehouse.gov/briefing-room/presidential-actions/2021/05/12/executive-order-on-improving-the-nations-cybersecurity/) is one such example.
+OpenSSF has produced a breadth of tools, frameworks, and specifications across the security space — SLSA, GUAC, Sigstore, Scorecard, OSV, OSPS Baseline, S2C2F, and many more — but adoption has been uneven. ORBIT's Launchpad gives *manufacturers* an on-ramp for adopting this work into their SDLCs; there is no equivalent program for the *maintainers* of the open-source projects these tools are mostly built for. Maintainers face a fragmented landscape: dozens of overlapping artifacts, unclear sequencing, no shared on-ramp. The revamped SCI WG exists to close that gap.
 
 ## Communications
 
@@ -30,16 +36,20 @@ Meeting Notes and Agendas are available on [Google Drive](https://docs.google.co
 
 * [User Stories](https://docs.google.com/document/d/1_TQizML8sXAm3OdoNA_plihZ14OHng_XRvJXKv_o_bs/edit?usp=sharing)
 
-## Activities
+## Sponsored Technical Initiatives
+
+Under the [Charter v2.0](./governance/CHARTER.md), the WG's operating relationship to its sponsored TIs is **enablement-driven**: each TI articulates annually how its work lowers adoption friction for some defined maintainer population; the WG offers brokering, research, and cross-TI integration capacity in return.
 
 * [Supply-chain Levels for Software Artifacts (SLSA, pronounced ”salsa”)](https://slsa.dev/) - see also the [SLSA repository](https://github.com/slsa-framework/slsa)
 * [SLSA Tooling Project](slsa-tooling.md)
 * [Factory for Repeatable Secure Creation of Artifacts (FRSCA, pronounced "fresca")](https://buildsec.github.io/frsca) - see also the [FRSCA repository](https://github.com/buildsec/frsca)
 * [Secure Supply Chain Consumption Framework (S2C2F)](https://github.com/ossf/s2c2f)
-* Supply Chain Integrity Positioning Special Interest Group (SIG)
-* [gittuf: A security layer for Git repositories](https://github.com/gittuf/gittuf)
+* [gittuf: verifiable security governance for git repositories](https://github.com/gittuf/gittuf)
 * [Graph for Understanding Artifact Composition (GUAC)](https://guac.sh) - see also the [GUAC repository](https://github.com/guacsec/guac)
 * [Zarf: Secure Software Delivery to Disconnected Systems](https://zarf.dev) - see also the [Zarf repository](https://github.com/zarf-dev/zarf)
+* [SBOMit](https://github.com/SBOMit) — attestation-based SBOM accuracy
+
+The Supply Chain Integrity Positioning SIG has been [sunset](./positioning-sig/README.md) as part of the v2.0 refocus; its outreach function is now central to the WG itself.
 
 Older activities (as Digital Identity Attestation WG):
   * [Former Digital Identity Attestation WG Readme](https://github.com/ossf/wg-supply-chain-integrity/blob/0804679461f7ed288d50d70da7ae9c7152b1e51d/README.md)
@@ -52,9 +62,8 @@ This WG is currently chaired by interim co-chairs Nicole Bates, Justin Cappos, a
 Working Group operations are consistent with standard operating guidelines provided by the OSSF Technical Advisory Committee
 [TAC](https://github.com/ossf/tac).
 
-Full details of process and roles are linked from [governance README](/governance).
-
-New SCI WG Charter can be read from [governance CHARTER](/governance/CHARTER.MD)
+- **Charter (proposed v2.0):** [`governance/CHARTER.md`](./governance/CHARTER.md) — submitted to the TAC per the [Q2 2026 WG report](https://github.com/ossf/tac/pull/614).
+- **Governance process:** [`governance/README.md`](./governance/README.md).
 
 ## Antitrust Policy Notice
 

--- a/governance/CHARTER.md
+++ b/governance/CHARTER.md
@@ -69,7 +69,7 @@ The following TIs are currently sponsored by the SCI WG. Each TI articulates ann
 - [SLSA Tooling Project](../slsa-tooling.md)
 - [AMPEL](https://github.com/carabiner-dev/ampel)
 - [Darnit](https://github.com/kusari-oss/darnit)
-
+* [BOMHort](https://github.com/seebom-labs/BOMHort) — Kubernetes-native SBOM visualization and governance
 No TI is being moved out of the WG as part of this charter.
 
 ## 8. Sub-project (TI) admission criteria

--- a/governance/CHARTER.md
+++ b/governance/CHARTER.md
@@ -1,155 +1,138 @@
-# OpenSSF Supply Chain Integrity WG Charter
+# OpenSSF Supply Chain Integrity Working Group - Charter
 
-_**June 2023:** We look to share the current Charter with the OpenSSF TAC within the next few weeks.  We hope to get approval from the TAC by end of July._
+*Status: **Proposed v2.0**, Q3 2026. Supersedes the unadopted 2023 draft. Submitted to the OpenSSF TAC for review per the Q2 2026 SCI WG report ([ossf/tac#614](https://github.com/ossf/tac/pull/614)).*
 
-_**April 2023:** We’re working within the SCI WG to refine this document to the point where it represents community consensus on our group’s priorities and direction. As we near the point of agreement we aim to share with the OpenSSF TAC for feedback before formal adoption._
+## 1. Overview
 
-## About this document
+The Supply Chain Integrity Working Group ("SCI WG") is the OpenSSF working group focused on lowering adoption cost for open-source maintainers across the OpenSSF tooling surface. It operates as a **front door and brokering layer**: sponsoring Technical Initiatives (TIs) whose primary value is reducing adoption friction, and routing maintainer needs to the appropriate sibling WG when they fall outside our remit.
 
-This document outlines a high-level summary of _a proposal_ for **OpenSSF Supply Chain Integrity WG’s direction as we progress through 2023.**
+## 2. Motivation
 
-The Mission and Vision are **intentionally expansive**, and anticipate years of work taking us beyond our progress to date.
+OpenSSF has produced a breadth of tools, frameworks, and specifications SLSA, GUAC, Sigstore, Scorecard, OSV, OSPS Baseline, S2C2F, and others, but adoption has been uneven. [ORBIT's Launchpad](https://github.com/ossf/wg-orbit) gives *manufacturers* an on-ramp for adopting this work; there is no equivalent program for the *maintainers* of the open-source projects these tools are mostly built for. Maintainers face overlapping artifacts, unclear sequencing, and no single OpenSSF venue chartered to make adoption easier.
 
-## Problem
-Modern software is componentized by nature, and its assembly usually involves parts provided by external suppliers (e.g., open or closed source libraries).
+The [OpenSSF Technical Vision](https://github.com/ossf/tac/blob/main/technical-vision.md) names "Producer Enablement" as a strategic pillar, and the [OSPS Baseline](https://github.com/ossf/security-baseline) is emerging as the unifying metric for what "good" looks like for open-source projects. What is missing is a working group whose explicit mission is to turn that vision and that metric into an adoption path without re-implementing work owned by sibling WGs.
 
-Today it is hard or impossible for those depending on externally supplied components to evaluate their inherent security features, or infer characteristics from the security-related procedures that were used in their creation. Any assessments that are possible are ad-hoc, and therefore hard or impossible to automate and reason about at scale.
+This is the gap the revamped SCI WG proposes to own, in line with the option named in the Q2 2026 SCI WG TAC report (PR #614, "Refocus the WG on adoption").
 
-Without the ability to assess the security properties of upstream components it is hard or impossible to:
-  * Quantify the risk of their use.
-  * Reason about the risk of their use.
-  * Manage and mitigate the risk of their use.
-  * Systematically reduce the risk of their use.
+## 3. Mission
 
-## Mission
-**Proposed SCI WG mission:**
-      _Scalable standardized attestable practices for supply chain security_
+> **Make adopting OpenSSF security tooling the easy default for open-source maintainers.**
 
-Scalable:
-  * A uniform approach across languages and ecosystems
-  * Automatable, with automation wherever possible
-  * Implementable at key points of leverage
+## 4. Measurable Objective
 
-Standardized:
-  * Shared vocabulary and problem model for the industry
-  * Ready interoperability up and down the supply chain
-  * Maximum reusability
+Within 12 months of charter adoption, every actively-maintained OpenSSF-recommended security practice has a documented, signposted, maintainer-tested adoption path that begins with *"I'm an open-source maintainer, where do I start?"* and ends with a measurable artifact (e.g., OSPS Baseline score, SLSA level, signed release). The SCI WG owns the on-ramp and the routing; sibling WGs continue to own the underlying practices.
 
-Attestable:
-  * Amenable to reproducible automatic evaluation
-  * Representable in machine-readable interchange formats
-  * Explicitly anchorable in appropriate roots of trust
+## 5. Scope
 
-## Vision
-We envision a future with:
+### 5.1 In scope
 
-  * A **pragmatic supply chain security framework** covering key functional areas
-    * An ergonomic decomposition of the problem space at the altitude of Build, Provenance, Dependencies, Source, and so on.
-    * Incrementally attainable levels that have a clear progression between each, enable explicit decisions around what level to aim for, and allow adopters to get started easily 
-    * Designed for the real world; adoptable in practice (e.g., FRSCA); deployable in enterprise contexts
+1. Maintainer-facing adoption on-ramps and decision aids across the OpenSSF tooling surface.
+2. Sponsorship of Technical Initiatives whose primary value proposition is lowering adoption cost for maintainers.
+3. Cross-WG brokering: maintaining a current map of "what OpenSSF has, who owns it, where to send a maintainer."
+4. Integration patterns and reference implementations that compose OpenSSF tooling end-to-end for a real maintainer workflow.
+5. Maintainer research and feedback channels: surveys, interviews, and logs fed back to producing WGs.
+6. Tracking maintainer-adoption metrics (e.g., OSPS Baseline coverage among sponsored TIs and showcase projects).
 
+### 5.2 Out of scope
 
-  * Upstream security practices **universally evaluable by downstream policy**
-    * Artifacts crossing supply chain boundaries are annotated with security-relevant metadata
-    * Data-driven control points are enabled throughout the supply chain
-    * Standard toolchains support generation of, and policy decisioning on, supply chain metadata
-    * An explicit threat model with consumer-selected trust anchors: those doing the trusting can decide who to trust, and on what basis (including regulatory constraints)
+1. Authoring or owning the OSPS Baseline itself - that's the [Best Practices WG / ORBIT WG](https://github.com/ossf/wg-orbit).
+2. Authoring or owning security tooling that is not adoption-focused - that's the [Security Tooling WG](https://github.com/ossf/wg-security-tooling) and Sigstore TIs.
+3. Coordinated vulnerability disclosure processes and policy - that's the [Vulnerability Disclosures WG](https://github.com/ossf/wg-vulnerability-disclosures).
+4. Manufacturer-side adoption - that's [ORBIT's Launchpad](https://github.com/ossf/wg-orbit).
+5. Targeted hardening of specific critical projects via paid engagement - that's [Alpha-Omega](https://alpha-omega.dev/).
+6. Adjudicating between competing technical approaches owned by other WGs.
 
+## 6. Relationship to existing initiatives
 
-  * **Ubiquitous adoption of the framework in Open Source**, with improved security posture as a result.
+The table below is reviewed annually with sibling-WG chairs. Where SCI publishes maintainer-facing material, it cites and links the owning WG's source of truth; if SCI discovers a gap, it files an issue with the owning WG before producing its own material.
 
-We anticipate an uplift in overall end-to-end security through:
-  * **Upstream adoption** of robust security practice, in line with the framework we define
-  * **Downstream risk control** using policy driven by upstream attestations of practice implementation
+| Initiative | Their remit | Our remit | Handoff line |
+|---|---|---|---|
+| **Best Practices WG** | Scorecard, BP Badge, general security curriculum, OSPS Baseline authorship | Maintainer-facing per-ecosystem cookbooks and clinic intake | "How do I improve my Scorecard score / what's a generally-secure-development practice?" -> BP; we link and notify BP liaison. |
+| **Security Tooling WG** | Curates the tool catalog; owns Sigstore-adjacent infrastructure | Packages and recommends tools in maintainer-ready recipes | Every cookbook is co-reviewed by a Security Tooling liaison; tool gaps surfaced in clinics file issues against their catalog. |
+| **Vulnerability Disclosures WG** | Coordinated disclosure norms, OSV schema, CVE program work | Pointers to disclosure / `SECURITY.md` / OSV inside recipes only | Any clinic intake touching a live or anticipated CVE is escalated within 24 hours to their triage contact. |
+| **ORBIT WG** | Manufacturer-side adoption (Launchpad); OSPS Baseline stewardship | Maintainer-side adoption; authorship of SCI-domain Baseline controls | Symmetric mirror across the maintainer<->manufacturer line. Quarterly joint session. |
+| **Alpha-Omega** | Funded targeted hardening of named critical projects | Long-tail, self-serve, maintainer-led on-ramps | Critical-infrastructure-scale intake routed to A-O; A-O graduates referred to us for ongoing self-serve resources. |
+| **AI/ML Security WG, Identity & Access WG, others** | Topical work in their domain | Route maintainer questions in their domain to them; fold their published maintainer-applicable practices into recipes | One row per sibling WG; updated annually with their chairs. |
 
-## Strategy and Principles
-We will use the principles below to guide us. In some cases we will stray from direct adherence but we’ll aim to only do so knowingly, with good reason.
+## 7. Sponsored Technical Initiatives
 
-  * Disappear into the infrastructure 
-    * Web users don’t have to worry about, or even think too consciously about, SSL. This is what supply chain security should look like to producers and consumers.
+The following TIs are currently sponsored by the SCI WG. Each TI articulates annually how its work lowers adoption friction for some defined maintainer population; the WG offers brokering, research, and cross-TI integration capacity in return.
 
-  * Target shared technical infrastructure as a strategic point of leverage
-    * Package managers: these form a critical trust boundary between open source producers and consumers.
-    * Widespread developer tools, CI/CD systems, operating systems: build atop common platforms and toolchains.
+- [SLSA](https://slsa.dev/) - supply-chain levels for software artifacts
+- [GUAC](https://guac.sh) - observability for the software supply chain
+- [gittuf](https://gittuf.dev/) - verifiable security governance for git
+- [Zarf](https://zarf.dev) - secure software delivery for connected and disconnected systems
+- [S2C2F](https://github.com/ossf/s2c2f) - secure supply chain consumption framework
+- [SBOMit](https://github.com/SBOMit) - attestation-based SBOM accuracy
+- [FRSCA](https://buildsec.github.io/frsca) - Factory for Repeatable Secure Creation of Artifacts
+- [SLSA Tooling Project](../slsa-tooling.md)
 
-  * Anchor trust in tools and systems, not processes and people
+No TI is being moved out of the WG as part of this charter.
 
-  * Focus on Open Source solutions, implementation, and adoption 
-    * The SCI WG _framework_ will be applicable beyond Open Source, but we’ll leave solutions for closed-source implementation and adoption to others, e.g., commercial tool vendors
-    * We anticipate SCI attestations and SCI-driven policy will flow transitively into closed source ecosystems, through the near-ubiquitous ingestion of Open Source dependencies.
-    * We will collaborate with [OpenSSF's Sterling Toolchain](https://docs.google.com/document/d/1H3Nk0PwmylLg5F7pqrIvyKzTyXAll0-f50B7DdqOh4A/edit#heading=h.9m0zi4b0wnne) efforts to ensure alignment.
+## 8. Sub-project (TI) admission criteria
 
-  * Draft off OpenSSF momentum
-    * Reuse work already in flight elsewhere in the OpenSSF ecosystem. For instance, the Best Practices WG is developing a glossary and vocab which we should snap to.
+A proposed Technical Initiative is eligible for SCI WG sponsorship when it demonstrates, at proposal time, both of the following:
 
-  _[…lots more needed here, including details on stakeholders and benefits to each]_
+1. It materially lowers adoption friction for open-source maintainers of at least one identified ecosystem, language, or build system, with maintainer-side reviewer signoff.
+2. It integrates with at least one other OpenSSF-sponsored TI, specification, or recommended practice.
 
-## Looking back on 2022
-A very brief snapshot of where we’re at, closing on the end of 2022:
+Admission requires consensus among the co-chairs (lazy consensus on the WG mailing list, five business days, no sustained objection) and written notice-of-no-objection to sibling WGs whose remit it touches. TIs whose primary value is research, specification authorship, or tool implementation should be directed to the WG whose remit best fits.
 
-* **Build** and **Provenance** (SLSA)
-  * SLSA standardizes secure practices for Build and Provenance, and an associated attestation format
-  * We anticipate a 1.0 specification in early 2023
-  * We close the year with some better clarity around SLSA/SBOM and SLSA/SSDF
-  * We have standalone SLSA builders and verifiers in place across languages
-    * GitHub Actions and Google Cloud Build can both generate SLSA provenance
-  * npm is implementing SLSA and Sigstore for end-to-end integrity of Node packages
-  * We have limited traction with SLSA provenance for policy decisioning
-    * e.g., Chainguard Enforce for k8s admissions control
-  * We have limited Open Source products shipping with SLSA provenance
-    * e.g., SUSE Linux, Flatcar Linux, Chainguard Images, Google Assured OSS
+## 9. Governance
 
+### 9.1 Co-chairs
 
-* **Dependencies** (S2C2F)
-  * S2C2F formally joined OpenSSF in October 2022 and standardizes secure practices for ingesting open source software into developer workflows
-    * No associated attestation format yet
-  * We are focusing on increasing awareness about our initiative as a recent OpenSSF joiner
-    * We recognize that there are opportunities for collaboration within the OpenSSF, so we are consolidating a strategy
-    * We will also be presenting the S2C2F at various engagements in early 2023
-	
-* **Source** (formerly SLSA)
-  * Secure practices for Source management were taken out of scope for SLSA 1.0
+Three co-chairs, staggered terms. Currently (interim, pending charter ratification): Nicole Bates, Justin Cappos, Michael Lieberman.
 
-* **Reference toolchain** (FRSCA)
-  * In addition we have a Factory for Repeatable Secure Creation of Artifacts (FRSCA), an open source reference implementation across [some subset of our practices].
+### 9.2 Decision-making
 
-## 2023 Priorities
-Proposed priorities for OpenSSF Supply Chain Integrity WG the coming year:
+- **Default decisions:** lazy consensus on the mailing list (5 business days, no sustained objection).
+- **Charter amendments, TI admission, TI sunset, co-chair changes:** consensus of the co-chairs after a mailing-list comment window (see Section 13).
+- **Co-chair elections:** held annually; process specified in a forthcoming Operating Procedures companion doc.
 
-* **Establish and cement community intention around Mission and Vision**
-  * Define our community, e.g., in concentric rings. Who is in ring 0? Ring 1? And so on.
-    * OpenSSF WGs
-    * Others in LF (e.g., DBoM)
-    * CDF, CNCF
-    * IETF (including SCITT)
-  * Circulate and socialize a version of this document with the community
-  * Generate buy-in and commitment to the long-term direction and near-term priorities
-  * Assess community health; plan and deliver tune-ups. Where do we need more participation?
-  * Develop specific outreach plan for community expansion. Which companies would we like to be involved, and how do we reach them?
-    * We need to be cognizant of our own biases as we undertake this exercise. Community should be inclusive and not about favorites.
-    * OpenSSF has some prior art and thinking we might leverage
+### 9.3 Conflicts of interest
 
-* **Exponentiate traction with Build and Provenance**
-  Land the first version of SLSA more substantively, with an approved specification and end-to-end implementation in major ecosystems.
-  * Specification to 1.0
-  * First end-to-end package manager implementations
-  * Key tooling components in place — foundations for more scalable implementations
-    * Triangulate with FRSCA and [Sterling Toolchain](https://docs.google.com/document/d/1z4YxuT6yzbgrNlUpgTbJhuKv5ngdsd6O8Dz5yRTepgs/edit#heading=h.r17cemgdt4tw) concept
-  * Major OSS projects on-boarded, generating and distributing provenance
-    * Idea: start with OpenSSF projects
+Standard Linux Foundation conflict-of-interest disclosure expected from co-chairs. Recusal expected on decisions involving a co-chair's employer's directly competing TI.
 
-* **Create momentum with Dependencies**
- With S2C2F now in OpenSSF, begin to [close some key gaps](https://docs.google.com/document/d/1Cp7TOVx7hWwxKGebWWPn4sGVIIbYSwR0-mWdwBO45po/edit#heading=h.y37mdlsrg0tq):
-  * Awareness and adoption; education, outreach, calls for participation, collaboration with key partners in OpenSSF
-  * Attestations and metadata; standardize contents and formats; explore distribution and discovery
-  * Tools for automatic assessment and attestation of conformance
+### 9.4 Future formalization (TODO)
 
-* Enable adoption with Tooling
-_[Need to decide how to approach this. Should tooling be consolidated SCI-wide? OpenSSF-wide? Or be owned by individual SIGs? E.g., slsa-tooling, s2c2f-tooling, sbom-tooling, etc.]_
+A formal Technical Steering Committee may be added by amendment once the WG has sustained active TI engagement; not blocking on charter adoption.
 
-* **Define SCI WG umbrella framework and begin standardization of the next functional area**
-  * Sketch, scope, and position uber-framework. Figure out how SLSA and S2C2F will naturally up-scope into this larger setting.
-    * This will necessarily depend on the problem statement above, anchoring all of this work.
-  * Requirements definition for Vulnerability Management
-    * Assessment of attestation approach; how much is automatable, trust-in-tool, etc?
-    * Extension of policy model beyond Build and Provenance
+## 10. Naming
+
+The WG's broader scope under this charter strains the literal reading of "Supply Chain Integrity." We considered renaming (candidates include *"Maintainer Enablement WG"* and *"Producer Enablement WG"*) and chose to preserve the SCI name for now, citing brand continuity and substantive overlap between supply-chain integrity and maintainer-side adoption. We commit to revisiting within 12 months of charter adoption.
+
+## 11. Intellectual property / licensing
+
+- Code: Apache License 2.0 with the Developer Certificate of Origin.
+- Documentation: Creative Commons Attribution 4.0.
+- Data: CDLA-Permissive 2.0.
+- Trademarks per Linux Foundation policy.
+- Alternative licenses require approval per Linux Foundation Governing Board policy.
+
+## 12. Community assets
+
+- Repository: https://github.com/ossf/wg-supply-chain-integrity
+- Mailing list: https://lists.openssf.org/g/openssf-supply-chain-integrity
+- Slack: `#wg_supply_chain_integrity` and the maintainer-facing `#maintainers` on the OpenSSF Slack
+- Public calendar: see [README](../README.md#meetings-times)
+- Meeting notes: [Google Drive](http://ssci.io/sci-notes)
+
+## 13. Amendments
+
+This charter may be amended by consensus of the co-chairs after 14 days' public notice on the WG mailing list, with notification to the OpenSSF TAC. Material changes like mission, scope, TI admission rule, or the introduction of a formal TSC, additionally require TAC review.
+
+## 14. Requested TAC action
+
+The SCI WG requests that the TAC review and approve this charter as the WG's adopted v2.0 charter. The WG separately notes for TAC consideration, on a timeline of the TAC's choosing, that the current OpenSSF project-to-WG topology mixes topical and functional groupings; a deliberate discussion of when each is appropriate would help future WGs orient. This is offered as input, not a request, and does not propose realignment of any current TI.
+
+## 15. References
+
+- Q2 2026 SCI WG TAC report - [ossf/tac#614](https://github.com/ossf/tac/pull/614)
+- "Maintainer Experience" issue - [ossf/tac#169](https://github.com/ossf/tac/issues/169)
+- ORBIT WG Charter - https://github.com/ossf/wg-orbit/blob/main/CHARTER.md
+- GovOps WG proposal - [ossf/tac#588](https://github.com/ossf/tac/issues/588)
+- OpenSSF Technical Vision - https://github.com/ossf/tac/blob/main/technical-vision.md
+- OSPS Baseline - https://github.com/ossf/security-baseline
+- Sandbox WG template - `ossf/tac/process/templates/WG_NAME_sandbox_stage.md`

--- a/governance/CHARTER.md
+++ b/governance/CHARTER.md
@@ -67,6 +67,8 @@ The following TIs are currently sponsored by the SCI WG. Each TI articulates ann
 - [SBOMit](https://github.com/SBOMit) - attestation-based SBOM accuracy
 - [FRSCA](https://buildsec.github.io/frsca) - Factory for Repeatable Secure Creation of Artifacts
 - [SLSA Tooling Project](../slsa-tooling.md)
+- [AMPEL](https://github.com/carabiner-dev/ampel)
+- [Darnit](https://github.com/kusari-oss/darnit)
 
 No TI is being moved out of the WG as part of this charter.
 

--- a/governance/README.md
+++ b/governance/README.md
@@ -1,3 +1,32 @@
-# Governance
+# SCI WG Governance
 
-TODO
+This directory holds the formal governance documents for the OpenSSF Supply Chain Integrity Working Group.
+
+## Documents
+
+- [**`CHARTER.md`**](./CHARTER.md) — the proposed v2.0 charter (Q3 2026). Repositions the WG as the OpenSSF maintainer front door. Submitted to the TAC per the [Q2 2026 SCI WG report](https://github.com/ossf/tac/pull/614).
+
+## Co-chairs
+
+Interim co-chairs (pending charter ratification): Nicole Bates, Justin Cappos, Michael Lieberman.
+
+## Decision-making
+
+Per Charter §9 and §16:
+
+- **Default decisions:** lazy consensus on the WG mailing list, five business days.
+- **Charter amendments, TI admission, TI sunset, co-chair changes:** consensus of the co-chairs after a mailing-list comment window.
+- **Amendments:** consensus of the co-chairs, 14 days' public notice on the mailing list, notification to the OpenSSF TAC; material changes (mission, scope, TI admission rule, introduction of a formal TSC) additionally require TAC review.
+- **Co-chair elections:** annually; mechanics in a forthcoming Operating Procedures companion doc.
+
+## Future formalization
+
+A formal Technical Steering Committee is **not** part of the current charter and is tracked as a deliberate TODO in [Charter §9.4](./CHARTER.md#94-future-formalization-todo). It may be added by amendment once the WG has sustained active TI engagement.
+
+## Sponsored Technical Initiatives
+
+See [Charter §7](./CHARTER.md#7-sponsored-technical-initiatives) for the current list and the WG's enablement-driven operating relationship to its TIs.
+
+## Amending this directory
+
+PRs against `CHARTER.md` or `governance/README.md` should reference the relevant mailing-list consensus thread (issue/PR link) in the description. Editorial / non-material updates may be merged by any co-chair after a 48-hour notice period on the mailing list.

--- a/positioning-sig/README.md
+++ b/positioning-sig/README.md
@@ -1,5 +1,9 @@
 # SCI WG - Positioning Special Interest Group
 
+> **Sunset notice (Q3 2026):** This SIG has been sunset as part of the SCI WG Charter v2.0 refocus. Its outreach function — landing page, clinic, conference presence, ecosystem cookbooks — is now central to the WG itself. See the [Charter v2.0](../governance/CHARTER.md). This directory is preserved for historical reference.
+
+---
+
 ## Objective
 
 ## Motivation


### PR DESCRIPTION
This is based on conversations at OSS NA 2026

Closes https://github.com/ossf/wg-supply-chain-integrity/issues/78.

## Summary of changes

- Fixes factual/attribution errors flagged in review.
- Moves volatile content (chair and TI rosters, sibling-WG relationships, objectives, community links) out of the charter into README.md.
- Replaces the open-ended future-governance TODO with a two-phase plan: chairs today, transitioning to a Steering Committee (seat allocation, elections, and company-representation caps defined).
- Realigns the document's structure, section order, and list style to match the [ORBIT WG charter](https://github.com/ossf/wg-orbit/blob/main/CHARTER.md), and adds the standard clauses that comparison showed were missing: Code of Conduct, voting quorum, TAC escalation, Linux Foundation community assets, and contributor copyright retention.
- Reworks Technical Initiative admission (Section 3) — see below.
- Removes drafting-process commentary and first-person voice that would go stale once adopted.

## Note for reviewers: Section 3 was reworked after initial review

Earlier revisions admitted a Technical Initiative based on what the project *is for* — it had to "materially lower adoption friction for open source maintainers," and TIs whose primary value was "research, specification authorship, or tool implementation" were routed elsewhere.

Applied to the portfolio the WG actually sponsors, that test disqualified nearly all of it, including SLSA. Almost no upstream project exists primarily to lower adoption friction; that is a working-group function, not a project one. ORBIT has the same shape and does not require each TI to individually embody its mission.

Section 3 now tests what an initiative **commits to** rather than what it is:

- **Admission (3.b)** — outputs an on-ramp can lead to; interoperates with at least two other OpenSSF artifacts, with evidence rather than a hyperlink; names an accountable representative.
- **Sponsorship obligations (3.c)** — current representative, quarterly reporting, an annual statement of how the work lowers adoption friction, and accepting maintainer feedback routed by the WG.
- **Sunset (3.d)** — review after two consecutive quarters without a representative or a report. A pre-adoption miss triggers written notice, never sunset on its own. Review may conclude continue-with-remediation, transfer, return to the TAC as unsponsored, or archive.

Section 1.d.i was also doing double duty as a portfolio constraint; it now says explicitly that it bounds what the WG authors, not what a sponsored initiative may author. Section 3.a confirms sponsorship leaves a TI's roadmap, maintainers, releases, and implementation decisions with the TI.
